### PR TITLE
Allow for ApplicationComponent namespacing

### DIFF
--- a/rubocop-cobra/lib/rubocop/cop/cobra/view_component_file_placement.rb
+++ b/rubocop-cobra/lib/rubocop/cop/cobra/view_component_file_placement.rb
@@ -14,15 +14,24 @@ module RuboCop
       # @example
       #   # bad
       #   # path: components/my_component/app/components/foo_component.rb
-      #   class FooComponent
+      #   class FooComponent < ::ViewComponent::Base
       #     # ...
       #   end
       #
       #   # bad
       #   # path: components/my_component/app/components/my_component/foo_component.rb
       #   module MyComponent
-      #     class FooComponent
+      #     class FooComponent < MyComponent::ApplicationComponent
       #       # ...
+      #     end
+      #   end
+      #
+      #   # acceptable
+      #   # path: components/my_component/app/components/my_component/application_component.rb
+      #   module MyComponent
+      #     class ApplicationComponent < ::ViewComponent::Base
+      #         # ...
+      #       end
       #     end
       #   end
       #
@@ -30,7 +39,7 @@ module RuboCop
       #   # path: components/my_component/app/components/my_component/resource/foo_component.rb
       #   module MyComponent
       #     module Resource
-      #       class FooComponent
+      #       class FooComponent < MyComponent::ApplicationComponent
       #         # ...
       #       end
       #     end
@@ -70,7 +79,7 @@ module RuboCop
           return false unless path.include?("#{component_path}/")
 
           sub_path = path.split("#{component_path}/").last
-          sub_path.include?("/")
+          sub_path.include?("/") || sub_path == "application_component.rb"
         end
 
         def correct_path

--- a/rubocop-cobra/spec/rubocop/cop/cobra/view_component_file_placement_spec.rb
+++ b/rubocop-cobra/spec/rubocop/cop/cobra/view_component_file_placement_spec.rb
@@ -19,13 +19,19 @@ RSpec.describe RuboCop::Cop::Cobra::ViewComponentFilePlacement do
 
       expect_no_offenses(source, file_path)
     end
+
+    it "when application_component is correctly namespaced" do
+      file_path = "root/components/my_component/app/components/my_component/application_component.rb"
+
+      expect_no_offenses(source, file_path)
+    end
   end
 
   context "registers an offense" do
     it "when view_component is defined directly inside app/components/" do
       source = <<~RUBY
-        class FooComponent
-        ^^^^^^^^^^^^^^^^^^ Nest ViewComponent definitions in the parent component and resource namespace. For example: `app/components/my_component/<resource>/foo_component.rb`
+        class FooComponent < ::ViewComponent::Base
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nest ViewComponent definitions in the parent component and resource namespace. For example: `app/components/my_component/<resource>/foo_component.rb`
         end
       RUBY
 
@@ -36,8 +42,8 @@ RSpec.describe RuboCop::Cop::Cobra::ViewComponentFilePlacement do
 
     it "when view_component is defined directly inside mismatched subdirectory of app/components/" do
       source = <<~RUBY
-        class FooComponent
-        ^^^^^^^^^^^^^^^^^^ Nest ViewComponent definitions in the parent component and resource namespace. For example: `app/components/my_component/<resource>/foo_component.rb`
+        class FooComponent < ::ViewComponent::Base
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nest ViewComponent definitions in the parent component and resource namespace. For example: `app/components/my_component/<resource>/foo_component.rb`
         end
       RUBY
 
@@ -48,8 +54,8 @@ RSpec.describe RuboCop::Cop::Cobra::ViewComponentFilePlacement do
 
     it "when view_component is defined directly inside mismatched subdirectory of app/components/" do
       source = <<~RUBY
-        class FooComponent
-        ^^^^^^^^^^^^^^^^^^ Nest ViewComponent definitions in the parent component and resource namespace. For example: `app/components/my_component/<resource>/foo_component.rb`
+        class FooComponent < ::ViewComponent::Base
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Nest ViewComponent definitions in the parent component and resource namespace. For example: `app/components/my_component/<resource>/foo_component.rb`
         end
       RUBY
 
@@ -62,7 +68,7 @@ RSpec.describe RuboCop::Cop::Cobra::ViewComponentFilePlacement do
       source = <<~RUBY
         module MyComponent
         ^^^^^^^^^^^^^^^^^^ Nest ViewComponent definitions in the parent component and resource namespace. For example: `app/components/my_component/<resource>/foo_component.rb`
-          class FooComponent
+          class FooComponent < MyComponent::ApplicationComponent
           end
         end
       RUBY


### PR DESCRIPTION
It's a standard practice to create an `ApplicationComponent`. This is a place we can `include` boilerplate additions.

This cop is extended to allow for a more top level namespace for `application_component.rb`s.

<img width="1101" alt="Screen Shot 2022-05-24 at 1 17 46 PM" src="https://user-images.githubusercontent.com/12770108/170269171-633922ea-7b03-404d-9009-1ac11e83d3ad.png">
