### PR TITLE
Fix Naming/ViewComponent - Patch to 0.4.1

### DIFF
--- a/rubocop-cobra/Gemfile.lock
+++ b/rubocop-cobra/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../rubocop-powerhome
   specs:
-    rubocop-powerhome (0.4.0)
+    rubocop-powerhome (0.4.1)
       rubocop
       rubocop-performance
       rubocop-rails

--- a/rubocop-powerhome/CHANGELOG.md
+++ b/rubocop-powerhome/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.4.1] - 2022-06-02
+
+- Fix bug in Naming/ViewComponent when class does not inherit
+
 ## [0.4.0] - 2022-06-01
 
 - Adds Naming/ViewComponent cop

--- a/rubocop-powerhome/Gemfile.lock
+++ b/rubocop-powerhome/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rubocop-powerhome (0.4.0)
+    rubocop-powerhome (0.4.1)
       rubocop
       rubocop-performance
       rubocop-rails

--- a/rubocop-powerhome/lib/rubocop/cop/naming/view_component.rb
+++ b/rubocop-powerhome/lib/rubocop/cop/naming/view_component.rb
@@ -30,7 +30,7 @@ module RuboCop
       private
 
         def view_component_class?(inheritance_klass)
-          inheritance_klass.end_with?("::ApplicationComponent", "ViewComponent::Base")
+          inheritance_klass&.end_with?("::ApplicationComponent", "ViewComponent::Base")
         end
       end
     end

--- a/rubocop-powerhome/lib/rubocop/powerhome/version.rb
+++ b/rubocop-powerhome/lib/rubocop/powerhome/version.rb
@@ -2,6 +2,6 @@
 
 module RuboCop
   module Powerhome
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end

--- a/rubocop-powerhome/spec/rubocop/cop/naming/view_component_spec.rb
+++ b/rubocop-powerhome/spec/rubocop/cop/naming/view_component_spec.rb
@@ -12,9 +12,16 @@ RSpec.describe RuboCop::Cop::Naming::ViewComponent do
     RUBY
   end
 
-  it "does not register offense for class that do not inherit from ApplicationComponent or ViewComponent::Base" do
+  it "does not register offense for class that does not inherit from ApplicationComponent or ViewComponent::Base" do
     expect_no_offenses(<<~RUBY)
       class Foo < ApplicationRecord
+      end
+    RUBY
+  end
+
+  it "does not register offense for class that does not inherit from anything" do
+    expect_no_offenses(<<~RUBY)
+      class Foo
       end
     RUBY
   end


### PR DESCRIPTION
See new test. This cop generates the error below without this fix.

```
Failure/Error: inheritance_klass.end_with?("::ApplicationComponent", "ViewComponent::Base")

NoMethodError:
  undefined method `end_with?' for nil:NilClass
```