### PR TITLE
custom release command

### DIFF
--- a/.github/workflows/eslint-config.yml
+++ b/.github/workflows/eslint-config.yml
@@ -32,7 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Node ${{ env.NODE_VERSION }}
-        if: steps.version-changed.outputs.any_changed == 'true'
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}

--- a/.github/workflows/rubocop-cobra.yml
+++ b/.github/workflows/rubocop-cobra.yml
@@ -38,7 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: xjunior/publish-rubygems-action@master
-        if: steps.version-changed.outputs.any_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           RUBYGEMS_API_KEY: ${{ secrets.rubygems_api_key }}

--- a/.github/workflows/rubocop-cobra.yml
+++ b/.github/workflows/rubocop-cobra.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: xjunior/publish-rubygems-action@master
         env:
+          RELEASE_COMMAND: rake build && gem push pkg/*
           GITHUB_TOKEN: ${{ secrets.github_token }}
           RUBYGEMS_API_KEY: ${{ secrets.rubygems_api_key }}
           WORKDIR: ${{ env.PROJECT_DIR }}

--- a/.github/workflows/rubocop-powerhome.yml
+++ b/.github/workflows/rubocop-powerhome.yml
@@ -38,7 +38,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: xjunior/publish-rubygems-action@master
-        if: steps.version-changed.outputs.any_changed == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           RUBYGEMS_API_KEY: ${{ secrets.rubygems_api_key }}

--- a/.github/workflows/rubocop-powerhome.yml
+++ b/.github/workflows/rubocop-powerhome.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: xjunior/publish-rubygems-action@master
         env:
+          RELEASE_COMMAND: rake build && gem push pkg/*
           GITHUB_TOKEN: ${{ secrets.github_token }}
           RUBYGEMS_API_KEY: ${{ secrets.rubygems_api_key }}
           WORKDIR: ${{ env.PROJECT_DIR }}


### PR DESCRIPTION
`rake release` attempts to create a git tag and push it, which is undesirable for us.

- Remove unnecessary release conditional
- Release with gem push instead of rake release
